### PR TITLE
solve problem with laravel migrations in mariadb and MySQL versions older than v5.7.7

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Facades\Schema;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -13,7 +14,7 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
+        Schema::defaultStringLength(191);
     }
 
     /**


### PR DESCRIPTION
solve problem with laravel migrations in mariadb and MySQL versions older than v5.7.7 => https://stackoverflow.com/questions/23786359/laravel-migration-unique-key-is-too-long-even-if-specified