### PR TITLE
Adding Marker Clusters on the Outlet Map

### DIFF
--- a/resources/views/outlets/map.blade.php
+++ b/resources/views/outlets/map.blade.php
@@ -10,6 +10,8 @@
 <link rel="stylesheet" href="https://unpkg.com/leaflet@1.3.1/dist/leaflet.css"
     integrity="sha512-Rksm5RenBEKSKFjgI3a41vrjkw4EVPlJ3+OiI65vTjIdo9brlAacEuKOiQ5OFh7cOI1bkDwLqdLw3Zg0cRJAAQ=="
     crossorigin=""/>
+<link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.4.1/dist/MarkerCluster.css" />
+<link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.4.1/dist/MarkerCluster.Default.css" />
 
 <style>
     #mapid { min-height: 500px; }
@@ -20,6 +22,7 @@
 <script src="https://unpkg.com/leaflet@1.3.1/dist/leaflet.js"
     integrity="sha512-/Nsx9X4HebavoBvEBuyp3I7od5tA0UzAxs+j83KgC8PU0kgB4XiK4Lfe4y4cgBtaRJQEIFCW+oC506aPT2L1zw=="
     crossorigin=""></script>
+<script src="https://unpkg.com/leaflet.markercluster@1.4.1/dist/leaflet.markercluster.js"></script>
 
 <script>
     var map = L.map('mapid').setView([{{ config('leaflet.map_center_latitude') }}, {{ config('leaflet.map_center_longitude') }}], {{ config('leaflet.zoom_level') }});
@@ -28,23 +31,26 @@
     L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
         attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
     }).addTo(map);
+    var markers = L.markerClusterGroup();
 
     axios.get('{{ route('api.outlets.index') }}')
     .then(function (response) {
         console.log(response.data);
-        L.geoJSON(response.data, {
+        var marker = L.geoJSON(response.data, {
             pointToLayer: function(geoJsonPoint, latlng) {
                 return L.marker(latlng);
             }
         })
         .bindPopup(function (layer) {
             return layer.feature.properties.map_popup_content;
-        }).addTo(map);
+        });
+        markers.addLayer(marker);
     })
     .catch(function (error) {
         console.log(error);
     });
 
+    map.addLayer(markers);
     @can('create', new App\Outlet)
     var theMarker;
 

--- a/resources/views/outlets/map.blade.php
+++ b/resources/views/outlets/map.blade.php
@@ -26,7 +26,6 @@
 
 <script>
     var map = L.map('mapid').setView([{{ config('leaflet.map_center_latitude') }}, {{ config('leaflet.map_center_longitude') }}], {{ config('leaflet.zoom_level') }});
-    var baseUrl = "{{ url('/') }}";
 
     L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
         attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
@@ -35,7 +34,6 @@
 
     axios.get('{{ route('api.outlets.index') }}')
     .then(function (response) {
-        console.log(response.data);
         var marker = L.geoJSON(response.data, {
             pointToLayer: function(geoJsonPoint, latlng) {
                 return L.marker(latlng).bindPopup(function (layer) {

--- a/resources/views/outlets/map.blade.php
+++ b/resources/views/outlets/map.blade.php
@@ -38,19 +38,18 @@
         console.log(response.data);
         var marker = L.geoJSON(response.data, {
             pointToLayer: function(geoJsonPoint, latlng) {
-                return L.marker(latlng);
+                return L.marker(latlng).bindPopup(function (layer) {
+                    return layer.feature.properties.map_popup_content;
+                });
             }
-        })
-        .bindPopup(function (layer) {
-            return layer.feature.properties.map_popup_content;
         });
         markers.addLayer(marker);
     })
     .catch(function (error) {
         console.log(error);
     });
-
     map.addLayer(markers);
+
     @can('create', new App\Outlet)
     var theMarker;
 


### PR DESCRIPTION
## Description

In this PR, we are adding marker cluster on the Outlet Map page. Related to #15 

## Before (no clustering)

![screen_2021-03-30_001](https://user-images.githubusercontent.com/8721551/113009760-d3dee480-91aa-11eb-9f21-07ba28bcc263.jpg)

## After (some markers are clustered)

![screen_2021-03-30_002](https://user-images.githubusercontent.com/8721551/113009781-d93c2f00-91aa-11eb-97b7-4fd8f317c51d.jpg)

Closes #15 